### PR TITLE
WIP / breaking change: Include empty constraint rates in table shipping

### DIFF
--- a/code/shippingmethods/ZonedShippingMethod.php
+++ b/code/shippingmethods/ZonedShippingMethod.php
@@ -29,6 +29,7 @@ class ZonedShippingMethod extends ShippingMethod {
 			"Quantity" => 'quantity'
 		);
 		$constraintfilters = array();
+		$emptyconstraint = array();
 		foreach($packageconstraints as $db => $pakval){
 			$mincol = "\"ZonedShippingRate\".\"{$db}Min\"";
 			$maxcol = "\"ZonedShippingRate\".\"{$db}Max\"";
@@ -39,7 +40,11 @@ class ZonedShippingMethod extends ShippingMethod {
 				" AND $maxcol >= " . $package->{$pakval}() .
 				" AND $mincol < $maxcol" . //sanity check
 			")";
+			//also include a special case where all constraints are empty
+			$emptyconstraint[] = "($mincol = 0 AND $maxcol = 0)";
 		}
+		$constraintfilters[] = "(".implode(" AND ", $emptyconstraint).")";
+
 		$filter = "(".implode(") AND (", array(
 			"\"ZonedShippingMethodID\" = ".$this->ID,
 			"\"ZoneID\" IN(".implode(",", $ids).")", //zone restriction

--- a/tests/ZonedShippingMethodTest.php
+++ b/tests/ZonedShippingMethodTest.php
@@ -1,106 +1,28 @@
 <?php
 
-class ZonedShippingMethodTest extends SapphireTest{
+class ZonedShippingMethodTest extends TableShippingMethodTest{
 	
 	static $fixture_file = array(
-		'shop_shipping/tests/fixtures/ZonedShippingMethod.yml',
-		'shop/tests/fixtures/Addresses.yml'
+		'shop_shipping/tests/fixtures/ZonedShippingMethod.yml'
 	);
-	
-	function setUp(){
-		parent::setUp();
-		$this->weightshipping = $this->objFromFixture("ZonedShippingMethod", "weight");
-		$this->volumeshipping = $this->objFromFixture("ZonedShippingMethod", "volume");
-		$this->valueshipping = $this->objFromFixture("ZonedShippingMethod", "value");
-		$this->quantityshipping = $this->objFromFixture("ZonedShippingMethod", "quantity");
 
-		$this->p0 = new ShippingPackage();
-		$this->p1 = new ShippingPackage(2.34, array(0.5,1,2), array('value' => 2, 'quantity' => 3));
-		$this->p2 = new ShippingPackage(17, array(1,2,3), array('value' => 6, 'quantity' => 10));
-		$this->p3 = new ShippingPackage(100, array(12.33,51,30.1), array('value' => 1000, 'quantity' => 55));
-		$this->p4 = new ShippingPackage(1000, array(100,200,300), array('value' => 1000000, 'quantity' => 12412));
-	}
-	
-	function testInternationalRates(){
-		$address_int = $this->objFromFixture("Address", "bukhp193eq"); //international address
-		
-		//weight based
-		$type = "weight";
-		$this->assertMatch($type, $this->p0, $address_int, 8); //weight = 0kg
-		$this->assertMatch($type, $this->p1, $address_int, 8); //weight = 2.34kg
-		$this->assertMatch($type, $this->p2, $address_int, 96); //weight= 17kg, 
-		$this->assertMatch($type, $this->p3, $address_int, 116); //weight = 100kg
-		$this->assertNoMatch($type, $this->p4, $address_int);  //weight = 1000kg
+	protected $fixtureclass = "ZonedShippingMethod";
 
-		//volume based
-		$type = "volume";
-		$this->assertMatch($type, $this->p0, $address_int, 2); //volume = 0cm3
-		$this->assertMatch($type, $this->p1, $address_int, 2); //volume = 1cm3
-		$this->assertMatch($type, $this->p2, $address_int, 6); //volume = 6cm3
-		$this->assertMatch($type, $this->p3, $address_int, 520); //volume = 18927.783cm3
-		$this->assertNoMatch($type, $this->p4, $address_int); //volume = 2000000cm3
+	//This test suite shares tests with TableShippingMethod
 
-		//value based
-		$type = "value";
-		$this->assertMatch($type, $this->p0, $address_int, 2); //value = $0
-		$this->assertMatch($type, $this->p1, $address_int, 2); //value = $2
-		$this->assertMatch($type, $this->p2, $address_int, 6); //value = $6
-		$this->assertNoMatch($type, $this->p3, $address_int); //value = $1000
-		$this->assertNoMatch($type, $this->p4, $address_int); //value = $1,000,000
+	public function testDefaultRate() {
+		$type = "address";
+		$address = $this->internationaladdress;
+		$defaultrate = new ZonedShippingRate(array(
+			"Rate" => 100,
+			"ZoneID" => $this->objFromFixture("Zone", "int")->ID
+		));
+		$defaultrate->write();
+		$this->addressshipping->Rates()->add($defaultrate);
 		
-		//quantity based
-		$type = "quantity";
-		$this->assertNoMatch($type, $this->p0, $address_int); //quantity = 0
-		$this->assertMatch($type, $this->p1, $address_int, 11); //quantity = 3
-		$this->assertMatch($type, $this->p2, $address_int, 18.6); //quantity = 10
-		$this->assertNoMatch($type, $this->p3, $address_int); //quantity = 155
-		$this->assertNoMatch($type, $this->p4, $address_int); //quantity = 12412
-	}
-	
-	function testLocalRates(){
-		$address_loc = $this->objFromFixture("Address", "wnz6022"); //New Zealand address
-		
-		//weight based
-		$type = "weight";
-		$this->assertMatch($type, $this->p0, $address_loc, 4); //weight = 0kg
-		$this->assertMatch($type, $this->p1, $address_loc, 4); //weight = 2.34kg
-		$this->assertMatch($type, $this->p2, $address_loc, 48); //weight= 17kg,
-		$this->assertMatch($type, $this->p3, $address_loc, 58); //weight = 100kg
-		$this->assertNoMatch($type, $this->p4, $address_loc);  //weight = 1000kg
-		
-		//volume based
-		$type = "volume";
-		$this->assertMatch($type, $this->p0, $address_loc, 1); //volume = 0cm3
-		$this->assertMatch($type, $this->p1, $address_loc, 1); //volume = 1cm3
-		$this->assertMatch($type, $this->p2, $address_loc, 3); //volume = 6cm3
-		$this->assertMatch($type, $this->p3, $address_loc, 520); //volume = 18927.783cm3
-		$this->assertNoMatch($type, $this->p4, $address_loc); //volume = 2000000cm3
-		
-		//value based
-		$type = "value";
-		$this->assertMatch($type, $this->p0, $address_loc, 1); //value = $0
-		$this->assertMatch($type, $this->p1, $address_loc, 1); //value = $2
-		$this->assertMatch($type, $this->p2, $address_loc, 3); //value = $6
-		$this->assertNoMatch($type, $this->p3, $address_loc); //value = $1000
-		$this->assertNoMatch($type, $this->p4, $address_loc); //value = $1,000,000
-		
-		//quantity based
-		$type = "quantity";
-		$this->assertNoMatch($type, $this->p0, $address_loc); //quantity = 0
-		$this->assertMatch($type, $this->p1, $address_loc, 5.5); //quantity = 3
-		$this->assertMatch($type, $this->p2, $address_loc, 9.3); //quantity = 10
-		$this->assertNoMatch($type, $this->p3, $address_loc); //quantity = 155
-		$this->assertNoMatch($type, $this->p4, $address_loc); //quantity = 12412
-	}
-	
-	function assertMatch($type = "weight", $package, $address, $amount, $message = ""){
-		$rate = $this->{$type."shipping"}->calculateRate($package,$address);
-		$this->assertEquals($rate,$amount,"Check rate for package $package is $amount. $message");
-	}
-	
-	function assertNoMatch($type = "weight", $package, $address, $message = ""){
-		$rate = $this->{$type."shipping"}->calculateRate($package,$address);
-		$this->assertNull($rate,"Check rate for package $package is not found. $message");
+		$this->assertMatch($type, $this->p0, $address, 100);
+		$this->assertMatch($type, $this->p2, $address, 100);
+		$this->assertMatch($type, $this->p4, $address, 100);
 	}
 	
 }

--- a/tests/fixtures/TableShippingMethod.yml
+++ b/tests/fixtures/TableShippingMethod.yml
@@ -19,6 +19,9 @@ TableShippingMethod:
         Name: Insured Table Shipping
         Description: Same as basic table shipping, but includes a tracking code.
         Enabled: 0
+    address:
+        Name: Address-based shipping
+        Enabled: 1
 TableShippingRate:
     #weight-based rates
     int_w4:
@@ -192,3 +195,18 @@ TableShippingRate:
         QuantityMin: 4
         QuantityMax: 10
         Rate: 9.30
+    #address-based rates
+    nz:
+        ShippingMethod: =>TableShippingMethod.address
+        Country: 'NZ'
+        Rate: 50
+    postcode6000:
+        ShippingMethod: =>TableShippingMethod.address
+        Country: 'NZ'
+        PostalCode: 6000
+        Rate: 45
+    wellington:
+        ShippingMethod: =>TableShippingMethod.address
+        Country: 'NZ'
+        State: 'Wellington'
+        Rate: 30

--- a/tests/fixtures/ZonedShippingMethod.yml
+++ b/tests/fixtures/ZonedShippingMethod.yml
@@ -3,7 +3,11 @@ Zone:
         Name: International
     loc:
         Name: Local
-        
+    nz6000:
+        Name: New Zealand 5032
+    wellington:
+        Name: Wellington NZ
+
 ZoneRegion:
     int:
         Country: '*'
@@ -11,6 +15,14 @@ ZoneRegion:
     loc:
         Country: 'NZ'
         Zone: =>Zone.loc
+    nz6000:
+        Country: 'NZ'
+        PostalCode: 6000
+        Zone: =>Zone.nz6000
+    wellington:
+        Country: 'NZ'
+        State: 'Wellington'
+        Zone: =>Zone.wellington
 
 ZonedShippingMethod:
     weight:
@@ -33,6 +45,9 @@ ZonedShippingMethod:
         Name: Insured Table Shipping
         Description: 'Same as basic table shipping, but includes a tracking code.'
         Enabled: 0
+    address:
+        Name: Address-based shipping
+        Enabled: 1
 ZonedShippingRate:
     #weight-based rates
     int_w4:
@@ -206,3 +221,16 @@ ZonedShippingRate:
         QuantityMin: 4
         QuantityMax: 10
         Rate: 9.30
+    #address-based rates
+    nz:
+        ZonedShippingMethod: =>ZonedShippingMethod.address
+        Zone: =>Zone.loc
+        Rate: 50
+    postcode6000:
+        ZonedShippingMethod: =>ZonedShippingMethod.address
+        Zone: =>Zone.nz6000
+        Rate: 45
+    wellington:
+        ZonedShippingMethod: =>ZonedShippingMethod.address
+        Zone: =>Zone.wellington
+        Rate: 30


### PR DESCRIPTION
@markguinn I just want to raise this with you first before making a breaking change.

Currently rates in both the table and zone shipping methods are excluded if they don't have any constraint values set. They are only included if at least one of the constraints has a max greater than 0.

I want to propose adding a special SQL check which includes rates that have no constraint values defined (e.g. min or max for any of weight, volume, value, quantity).

The use case for this is that someone may only want to be constraining on address / zone, and nothing else. They would have to add fictitious maximum values like 99999 to every rate to get it to behave that way. This will of course affect any sites that already have empty constraint rates....such as if an admin has created a rate, saved and done nothing. That could result in accidental free shipping.

So if you are happy with this change to go into 1.0.0 of shop_shipping, I'll finish off tests, and also repeat the work in Zoned shipping.

## Future idea:

In future we could allow devs to hide certain types of constraints, making the UI a bit easier to understand. Perhaps users choose the constraints they want to use when initially choosing the Table / Zone shipping method.