### PR TITLE
Updated ShippingEstimateForm, template and test

### DIFF
--- a/code/extensions/CartPageShippingExtension.php
+++ b/code/extensions/CartPageShippingExtension.php
@@ -10,7 +10,7 @@ class CartPageShippingExtension extends Extension{
 		return new ShippingEstimateForm($this->owner);
 	}
 	
-	function ShippingEstimates() {
+	public function ShippingEstimates() {
 		$estimates = Session::get("ShippingEstimates");
 		Session::set("ShippingEstimates", null);
 		Session::clear("ShippingEstimates");

--- a/code/forms/ShippingEstimateForm.php
+++ b/code/forms/ShippingEstimateForm.php
@@ -3,13 +3,9 @@
 class ShippingEstimateForm extends Form{
 	
 	function __construct($controller, $name = "ShippingEstimateForm") {
-		$countries = SiteConfig::current_site_config()->getCountriesList();
-		$countryfield = (count($countries)) ? 
-			DropdownField::create("Country", _t('Address.COUNTRY', 'Country'), $countries) : 
-			ReadonlyField::create("Country", _t('Address.COUNTRY', 'Country'));
-		$countryfield->setHasEmptyDefault(true);
+		$address = new Address();  // get address to access it's getCountryField method
 		$fields = new FieldList(
-			$countryfield,
+			$address->getCountryField(),
 			TextField::create('State', _t('Address.STATE', 'State')),
 			TextField::create('City', _t('Address.CITY', 'City')),
 			TextField::create('PostalCode', _t('Address.POSTALCODE', 'Postal Code'))
@@ -25,6 +21,9 @@ class ShippingEstimateForm extends Form{
 	}
 	
 	function submit($data, $form) {
+		if($country = SiteConfig::current_site_config()->getSingleCountry()){  // Add Country if missing due to ReadonlyField in form
+			$data['Country'] = $country;
+		}
 		if($order = ShoppingCart::singleton()->current()){
 			$estimator = new ShippingEstimator(
 				$order,

--- a/templates/Includes/ShippingEstimates.ss
+++ b/templates/Includes/ShippingEstimates.ss
@@ -1,20 +1,22 @@
-<% if ShippingEstimates %>
-	<table class="table estimatelist">
-		<thead>
+<table class="table estimatelist">
+	<thead>
+		<tr>
+			<th>Rate</th>
+			<th>Name</th>
+			<th>Description</th>
+		</tr>
+	</thead>
+	<tbody>
+		<% loop ShippingEstimates %>
 			<tr>
-				<th>Rate</th>
-				<th>Name</th>
-				<th>Description</th>
-			</tr>
-		</thead>
-		<tbody>
-			<% loop ShippingEstimates %>
-				<tr>
-					<td>$Rate.Nice</td>
+				<td>$Rate.Nice</td>
+				<% if $Name == "ShippingEstimates" %>
+					<td></td>
+				<% else %>
 					<td>$Name</td>
-					<td>$Description</td>
-				</tr>
-			<% end_loop %>
-		</tbody>
-	</table>
-<% end_if %>
+				<% end_if %>
+				<td>$Description</td>
+			</tr>
+		<% end_loop %>
+	</tbody>
+</table>

--- a/tests/ShippingEstimateFormTest.php
+++ b/tests/ShippingEstimateFormTest.php
@@ -7,40 +7,101 @@ class ShippingEstimateFormTest extends FunctionalTest{
 		"shop/tests/fixtures/shop.yml",
 		"shop/tests/fixtures/Pages.yml"
 	);
-	
+	protected static $use_draft_site = true;
+
 	function setUp() {
+		if(method_exists('SapphireTest', 'useTestTheme')){
+			$this->useTestTheme($themeBaseDir = dirname(__FILE__), 'testtheme', function(){});
+		} else {
+			$this->useTheme('testtheme');
+		}
 		parent::setUp();
 		ShopTest::setConfiguration();
+		// add product to the cart
+		$this->socks = $this->objFromFixture('Product', 'socks');
+		$this->socks->publish('Stage','Live');
+
 		$this->cartpage = $this->objFromFixture("CartPage", "cart");
 		$this->cartpage->publish('Stage','Live');
 		ShoppingCart::singleton()->setCurrent($this->objFromFixture("Order", "cart")); //set the current cart
+
+		// Open cart page
+		$page = $this->get('/cart');
 	}
 	
 	function testGetEstimates() {
-		
-		$resp = $this->get('/cart'); //required to prep things
-		//good data
+
+		//good data for Shipping Estimate Form
 		$data = array(
 			'Country' => 'NZ',
 			'State' => 'Auckland',
 			'City' => 'Auckland',
 			'PostalCode' => 1010
 		);
-		$resp = $this->post('/cart/ShippingEstimateForm', $data);
+		$page1 = $this->post('/cart/ShippingEstimateForm', $data);
+		$this->assertEquals(200, $page1->getStatusCode(), "a page should load");
+		$this->assertContains("Quantity-based shipping", $page1->getBody(), "ShippingEstimates presented in a table");
+
 		
-		//TODO: assertions
-		
-		//un-escaped data
+		//un-escaped data for Shipping Estimate Form
 		$data = array(
 			'Country' => 'NZ',
 			'State' => 'Hawke\'s Bay',
 			'City' => 'SELECT * FROM \" \' WHERE AND EVIL',
 			'PostalCode' => 1234
 		);
-		$resp = $this->post('/cart/ShippingEstimateForm', $data);
+		$page2 = $this->post('/cart/ShippingEstimateForm', $data);
+		$this->assertEquals(200, $page2->getStatusCode(), "a page should load");
+		$this->assertContains("Quantity-based shipping", $page2->getBody(), "ShippingEstimates can be successfully presented with un-escaped data in the form");
+
+	}
+
+	function testShippingEstimateWithReadonlyFieldForCountry() {
+		// setup a single-country site
+		$siteconfig = DataObject::get_one('SiteConfig');
+		$siteconfig->AllowedCountries = "NZ";
+		$siteconfig->write();
+
+		// Open cart page where Country field is readonly
+		$page = $this->get('/cart');
+		$this->assertContains("Country_readonly", $page->getBody(), "The Country field is readonly");
+		$this->assertNotContains("<option value=\"NZ\">New Zealand</option>", $page->getBody(), "Dropdown field is not shown");
+
+		// The Shipping Estimate Form can post with a Country readonly field
+		$data = array(
+			'State' => 'Waikato',
+			'City' => 'Hamilton',
+			'PostalCode' => 3210
+		);
+		$page3 = $this->post('/cart/ShippingEstimateForm', $data);
+		$this->assertEquals(200, $page3->getStatusCode(), "a page should load");
+		$this->assertContains("Quantity-based shipping", $page3->getBody(), "ShippingEstimates can be successfully presented with a Country readonly field");
 		
-		//TODO: assertions
-		$this->markTestIncomplete("add assertions");
+
+	}
+
+
+	/**
+ 	* Test against a SS Shop Shipping theme
+ 	*
+ 	* Template CartPage.ss contains <% include ShippingEstimator %>
+ 	* Function adapted from SSViewerTest.php in SSv3.1
+ 	* @param $theme string - theme name
+ 	*/
+ 	protected function useTheme($theme) {
+		global $project;
+
+		$themeBaseDir = dirname(__FILE__);
+		$manifest = new SS_TemplateManifest($themeBaseDir, $project, true, true);
+
+		SS_TemplateLoader::instance()->pushManifest($manifest);
+
+		$origTheme = Config::inst()->get('SSViewer', 'theme');
+		Config::inst()->update('SSViewer', 'theme', $theme);
+
+		// Remove all the test themes we created
+		SS_TemplateLoader::instance()->popManifest();
+		Config::inst()->update('SSViewer', 'theme', $origTheme);
 	}
 	
 }

--- a/tests/testtheme/templates/Layout/CartPage.ss
+++ b/tests/testtheme/templates/Layout/CartPage.ss
@@ -1,0 +1,37 @@
+<% require ThemedCSS(checkout,shop) %>
+<h1 class="pagetitle">$Title</h1>
+<div class="typography">
+	<% if Content %>
+		$Content
+	<% end_if %>
+</div>
+<% if Cart %>
+	
+	<% if CartForm %>
+		$CartForm
+
+		<!-- start Shipping Estimator -->
+		<% include ShippingEstimator %>
+		<!-- finish Shipping Estimator -->
+		
+	<% else %>
+		<% with Cart %><% include Cart Editable=true %><% end_with %>
+	<% end_if %>
+	
+<% else %>
+	<p class="message warning"><% _t('CartPage.ss.CARTEMPTY','Your cart is empty.') %></p>
+<% end_if %>
+<div class="cartfooter">
+	<% if ContinueLink %>
+		<a class="continuelink button" href="$ContinueLink">
+			<% _t('CartPage.ss.CONTINUE','Continue Shopping') %>
+		</a>
+	<% end_if %>
+	<% if Cart %>
+		<% if CheckoutLink %>
+			<a class="checkoutlink button" href="$CheckoutLink">
+				<% _t('CartPage.ss.PROCEEDTOCHECKOUT','Proceed to Checkout') %>
+			</a>
+		<% end_if %>
+	<% end_if %>
+</div>


### PR DESCRIPTION
Used the getCountryField method of the Shop's Address model to create either a dropdown or a readonly field for the Country field in the form.

Updated ShippingEstimates.ss for NIL results within loop.  The results for the template are provided by the public function ShippingEstimates within CartPageShippingExtension class.  This function is called twice, once from the 'if' in the template and then 'loop'.  When called a second time, it looks for the session variable that was cleared in the initial call (that was when the 'if' was called from the template).  Then when the loop step occurs, the data has gone.  Therefore, remove the 'if' from the template and call only once from 'loop'.  Display a blank table row if there is no data.

Updated ShippingEstimateFormTests to test submitting with a dropdown field, bad data, and a readonly field.
If SS >=3.2, use SapphireTest's useTestTheme function otherwise use $this->useTheme.  These functions direct the test to a dedicated theme that includes <% include Shipping Estimator %>.

This pull request replaces the one from branch CountryReadonlyField, which will be closed and the branch deleted.